### PR TITLE
Fix bug when opening empty file

### DIFF
--- a/ParquetReader/ColumnBuffer.go
+++ b/ParquetReader/ColumnBuffer.go
@@ -43,7 +43,9 @@ func NewColumnBuffer(pFile ParquetFile.ParquetFile, footer *parquet.FileMetaData
 		PathStr:          pathStr,
 		DataTableNumRows: -1,
 	}
-	err = res.NextRowGroup()
+	if err = res.NextRowGroup(); err == io.EOF {
+		err = nil
+	}
 	return res, err
 }
 
@@ -53,7 +55,7 @@ func (self *ColumnBufferType) NextRowGroup() error {
 	ln := int64(len(rowGroups))
 	if self.RowGroupIndex >= ln {
 		self.DataTableNumRows++ //very important, because DataTableNumRows is one smaller than real rows number
-		return fmt.Errorf("End of row groups")
+		return io.EOF
 	}
 	self.RowGroupIndex++
 


### PR DESCRIPTION
### Context
There is a problem when opening empty file. This issue was resolved in https://github.com/xitongsys/parquet-go/blob/master/reader/columnbuffer.go#L57-L60

### Changes
* [x] Return `io.EOF` 